### PR TITLE
fixed twig filter

### DIFF
--- a/Twig/Extension/AttachmentExtension.php
+++ b/Twig/Extension/AttachmentExtension.php
@@ -56,7 +56,7 @@ class AttachmentExtension extends \Twig_Extension
         
         if (null === $filter)
         {
-            return '';
+            return $url;
         }
         
         return $this->cacheManager->getBrowserPath($url, $filter, $absolute);


### PR DESCRIPTION
twig filter returned an empty string if it was used without the liip_imagine filter
